### PR TITLE
encalve -> enclave

### DIFF
--- a/qemu/target-i386/sgx_helper.c
+++ b/qemu/target-i386/sgx_helper.c
@@ -1237,7 +1237,7 @@ void sgx_egetkey_common_check(CPUX86State *env, uint64_t *reg,
     }
 
     /* If reg is not properly aligned, then GP(0) */
-    // FIXME: enforce memory alignment with array declaration inside the encalve.
+    // FIXME: enforce memory alignment with array declaration inside the enclave.
     // is_aligned((void *)reg, alignment, env);
 
     /* Check reg is an EPC address */

--- a/user/README
+++ b/user/README
@@ -41,7 +41,7 @@ c. Current settings
    - Stack per thread size:
 
 d. ECP Memory layout
-   - Consider the case of adding one encalve.
+   - Consider the case of adding one enclave.
 
    =========================================
                   EPC Addr Begin
@@ -79,7 +79,7 @@ f. Security features
                        RESERVED, MISCSELECT*, MISCMASK*, RESERVED2,
                        ATTRIBUTE, ATTRIBUTEMASK, ENCLAVEHASH, RESERVED3,
                        ISVPROID, ISVSVN
-   - Enclave measurement: sigstruct.encalvehash == secs.mrenclave
+   - Enclave measurement: sigstruct.enclavehash == secs.mrenclave
      - Before execute EINIT, EEXTEND is used to measure enclave and update the
        sec.mrenclave vaule.
 

--- a/user/sgx-kern.c
+++ b/user/sgx-kern.c
@@ -487,7 +487,7 @@ int sys_create_enclave(void *base, unsigned int code_pages,
     // allocate secs
     int enclave_size = PAGE_SIZE * npages;
     printf("DEBUG npages is %d\n",npages);
-    printf("encalve size is %x\n", PAGE_SIZE * npages);
+    printf("enclave size is %x\n", PAGE_SIZE * npages);
 
     void *enclave_addr = epc_to_vaddr(enclave);
 


### PR DESCRIPTION
Fixes spelling of enclave in a couple of places.