### PR TITLE
Fixed is_debuggable_enclave_hash

### DIFF
--- a/qemu/target-i386/sgx_helper.c
+++ b/qemu/target-i386/sgx_helper.c
@@ -3647,10 +3647,10 @@ bool verify_signature(sigstruct_t *sig, uint8_t *signature, uint8_t *modulus,
 }
 
 static
-bool is_debuggable_enclave_hash(uint8_t hash[32])
+bool is_debuggable_enclave_hash(const uint8_t* hash)
 {
     int i;
-    for (i = 0; i < sizeof(hash); i ++)
+    for (i = 0; i < 32; i ++)
         if (hash[i] != 0)
             return false;
     return true;


### PR DESCRIPTION
The parameter was confusing. Note that `sizeof(hash)` was actually `sizeof(uint8_t*)`.
