### PR TITLE
AES-CMAC128 security bugfix

### DIFF
--- a/qemu/target-i386/sgx-utils.c
+++ b/qemu/target-i386/sgx-utils.c
@@ -36,7 +36,9 @@ void load_rsa_key_from_str(uint8_t *key, char *bytes, size_t size)
 {
     int i;
     for (i = 0; i < size; i++) {
-        sscanf(bytes + i*2, "%02X", (unsigned int *)&key[i]);
+        unsigned int value;
+        sscanf(bytes + i*2, "%02X", &value);
+        key[i] = (uint8_t)value;
     }
 
     if (sgx_dbg_rsa) {

--- a/user/polarssl/aes_cmac128.c
+++ b/user/polarssl/aes_cmac128.c
@@ -160,8 +160,6 @@ void aes_cmac128_update(aes_cmac128_context *ctx, const uint8_t *_msg, size_t _m
  */
 void aes_cmac128_final(aes_cmac128_context *ctx, uint8_t T[16])
 {
-    unsigned char iv[16] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 
-                                0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
     uint8_t tmp_block[16];
     uint8_t Y[16];
 

--- a/user/polarssl/aes_cmac128.c
+++ b/user/polarssl/aes_cmac128.c
@@ -54,7 +54,6 @@ static inline void aes_cmac_128_xor(const uint8_t in1[16], const uint8_t in2[16]
 void aes_cmac128_starts(aes_cmac128_context *ctx, const uint8_t K[16])
 {
     uint8_t L[16];
-    unsigned char iv[16] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
 
     /* Zero struct of aes_context */
     ZERO_STRUCTP(ctx);
@@ -62,7 +61,7 @@ void aes_cmac128_starts(aes_cmac128_context *ctx, const uint8_t K[16])
     aes_setkey_enc(&ctx->aes_key, K, 128);
 
     /* step 1 - generate subkeys k1 and k2 */
-    aes_crypt_cbc(&ctx->aes_key, AES_ENCRYPT, 16, iv, const_Zero, L);
+    aes_crypt_ecb(&ctx->aes_key, AES_ENCRYPT, const_Zero, L);
 
     if (_MSB(L) == 0) {
         aes_cmac_128_left_shift_1(L, ctx->K1);
@@ -92,7 +91,6 @@ void aes_cmac128_starts(aes_cmac128_context *ctx, const uint8_t K[16])
  */
 void aes_cmac128_update(aes_cmac128_context *ctx, const uint8_t *_msg, size_t _msg_len)
 {
-    unsigned char iv[16] = {0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00};
     uint8_t tmp_block[16];
     uint8_t Y[16];
     const uint8_t *msg = _msg;
@@ -135,7 +133,7 @@ void aes_cmac128_update(aes_cmac128_context *ctx, const uint8_t *_msg, size_t _m
      * now checksum everything but the last block
      */
     aes_cmac_128_xor(ctx->X, tmp_block, Y);
-    aes_crypt_cbc(&ctx->aes_key, AES_ENCRYPT, 16, iv, Y, ctx->X);
+    aes_crypt_ecb(&ctx->aes_key, AES_ENCRYPT, Y, ctx->X);
 
     while (msg_len > 16) {
         memcpy(tmp_block, msg, 16);
@@ -143,7 +141,7 @@ void aes_cmac128_update(aes_cmac128_context *ctx, const uint8_t *_msg, size_t _m
         msg_len -= 16;
 
         aes_cmac_128_xor(ctx->X, tmp_block, Y);
-        aes_crypt_cbc(&ctx->aes_key, AES_ENCRYPT, 16, iv, Y, ctx->X);
+        aes_crypt_ecb(&ctx->aes_key, AES_ENCRYPT, Y, ctx->X);
     }
 
     /*
@@ -175,7 +173,7 @@ void aes_cmac128_final(aes_cmac128_context *ctx, uint8_t T[16])
     }
 
     aes_cmac_128_xor(tmp_block, ctx->X, Y);
-    aes_crypt_cbc(&ctx->aes_key, AES_ENCRYPT, 16, iv, Y, T);
+    aes_crypt_ecb(&ctx->aes_key, AES_ENCRYPT, Y, T);
 
     ZERO_STRUCT(tmp_block);
     ZERO_STRUCT(Y);


### PR DESCRIPTION
IV does not remain constant zero using polarssl function `aes_crypt_cbc` All blocks except last two cancel out due to double XOR! Now using `aes_crypt_ecb` instead.
