### PR TITLE
Escape braces in regex.

### DIFF
--- a/qemu/scripts/texi2pod.pl
+++ b/qemu/scripts/texi2pod.pl
@@ -317,7 +317,7 @@ while(<$inf>) {
 	@columns = ();
 	for $column (split (/\s*\@tab\s*/, $1)) {
 	    # @strong{...} is used a @headitem work-alike
-	    $column =~ s/^\@strong{(.*)}$/$1/;
+	    $column =~ s/^\@strong\{(.*)\}$/$1/;
 	    push @columns, $column;
 	}
 	$_ = "\n=item ".join (" : ", @columns)."\n";


### PR DESCRIPTION
Unescaped braces in regex causes syntax error instead of warning in Perl 5.26.