### PR TITLE
Fix escaping issue in perl regex in QEMU

### DIFF
--- a/qemu/scripts/texi2pod.pl
+++ b/qemu/scripts/texi2pod.pl
@@ -317,7 +317,7 @@ while(<$inf>) {
 	@columns = ();
 	for $column (split (/\s*\@tab\s*/, $1)) {
 	    # @strong{...} is used a @headitem work-alike
-	    $column =~ s/^\@strong{(.*)}$/$1/;
+	    $column =~ s/^\@strong\{(.*)\}$/$1/;
 	    push @columns, $column;
 	}
 	$_ = "\n=item ".join (" : ", @columns)."\n";


### PR DESCRIPTION
This is from:
https://github.com/qemu/qemu/commit/aa5ccadcca3e6018ebd9d2e8b0a0604f7cb0cd59

Fixes issue #54 