### PR TITLE
Fix qemu compilation on Linux

### DIFF
--- a/qemu/scripts/texi2pod.pl
+++ b/qemu/scripts/texi2pod.pl
@@ -317,7 +317,7 @@ while(<$inf>) {
 	@columns = ();
 	for $column (split (/\s*\@tab\s*/, $1)) {
 	    # @strong{...} is used a @headitem work-alike
-	    $column =~ s/^\@strong{(.*)}$/$1/;
+	    $column =~ s/^\@strong\{(.*)\}$/$1/;
 	    push @columns, $column;
 	}
 	$_ = "\n=item ".join (" : ", @columns)."\n";

--- a/qemu/user-exec.c
+++ b/qemu/user-exec.c
@@ -57,7 +57,7 @@ static void exception_action(CPUState *cpu)
 void cpu_resume_from_signal(CPUState *cpu, void *puc)
 {
 #ifdef __linux__
-    struct ucontext *uc = puc;
+    struct ucontext_t *uc = puc;
 #elif defined(__OpenBSD__)
     struct sigcontext *uc = puc;
 #endif
@@ -222,7 +222,7 @@ int cpu_signal_handler(int host_signum, void *pinfo,
 {
     siginfo_t *info = pinfo;
     unsigned long pc;
-#if defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__)
+#if defined(__NetBSD__) || defined(__FreeBSD__) || defined(__DragonFly__) || defined(__linux__)
     ucontext_t *uc = puc;
 #elif defined(__OpenBSD__)
     struct sigcontext *uc = puc;


### PR DESCRIPTION
 * `ucontext` -> `ucontext_t`
 * fix perl regex in docs generation

```
$ uname -a
Linux monolith 4.14.4-1-userns #1 SMP PREEMPT Tue Jan 2 08:41:04 PST 2018 x86_64 GNU/Linux
$ perl -v
This is perl 5, version 26, subversion 1 (v5.26.1) built for x86_64-linux-thread-multi
```